### PR TITLE
Vi/chat id msgs permissions

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -132,6 +132,13 @@ export class AuthService {
 		return this.userIdFromCookieString(cookie);
 	}
 
+	async validUserId(request: Request): Promise<number> {
+		const userId = await this.userId(request);
+		await this.userService.findOne({ where: { id: userId } });
+
+		return userId;
+	}
+
 	userIdFromCookieString(cookie: string) {
 		try {
 			const data = this.jwtService.verify(cookie);

--- a/backend/src/chats/chat-user-permissions/entities/chat-user-permission.entity.ts
+++ b/backend/src/chats/chat-user-permissions/entities/chat-user-permission.entity.ts
@@ -56,7 +56,7 @@ export class ChatUserPermission {
 
 	@IsIn(permissionsArray)
 	@Column()
-	permission: String;
+	permission: permissionsEnum;
 
 	@CreateDateColumn()
 	created_at: Date;

--- a/backend/src/chats/chat/chat.module.ts
+++ b/backend/src/chats/chat/chat.module.ts
@@ -6,10 +6,12 @@ import { Chat } from './entities/chat.entity';
 import { MessageModule } from '../message/message.module';
 import { SocketModule } from '../../socket/socket.module';
 import { ChatUserPermissionModule } from '../chat-user-permissions/chat-user-permission.module';
+import { AuthModule } from '../../auth/auth.module';
 
 @Module({
 	imports: [
 		TypeOrmModule.forFeature([Chat]),
+		AuthModule,
 		ChatUserPermissionModule,
 		MessageModule,
 		SocketModule,

--- a/backend/src/chats/chat/dto/create-chat.dto.ts
+++ b/backend/src/chats/chat/dto/create-chat.dto.ts
@@ -1,18 +1,19 @@
 import { IsNotEmpty, IsOptional } from 'class-validator';
 import { UserInChat } from '../../../users/user/entities/user.entity';
+import { ChatType, ChatVisibility } from '../entities/chat.entity';
 
 export class CreateChatDto {
 	@IsNotEmpty()
 	name: string;
 
 	@IsOptional()
-	visibility?: string;
+	visibility?: ChatVisibility;
 
 	@IsOptional()
 	password?: string;
 
 	@IsOptional()
-	type?: string;
+	type?: ChatType;
 
 	@IsOptional()
 	users?: UserInChat[];

--- a/backend/src/chats/chat/dto/update-chat.dto.ts
+++ b/backend/src/chats/chat/dto/update-chat.dto.ts
@@ -1,13 +1,14 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateChatDto } from './create-chat.dto';
 import { IsNotEmpty, IsOptional, ValidateIf } from 'class-validator';
+import { ChatVisibility } from '../entities/chat.entity';
 
 export class UpdateChatDto extends PartialType(CreateChatDto) {
 	@IsOptional()
 	name?: string;
 
 	@IsOptional()
-	visibility?: string;
+	visibility?: ChatVisibility;
 
 	@ValidateIf((o) => o.hasOwnProperty('password'))
 	@IsOptional()

--- a/backend/src/chats/chat/entities/chat.entity.ts
+++ b/backend/src/chats/chat/entities/chat.entity.ts
@@ -7,14 +7,6 @@ import { User } from '../../../users/user/entities/user.entity';
 
 const validVisibility = ['public', 'private'];
 const chatType = ['dm', 'channel'];
-// export enum ChatType {
-// 	DM = 'dm',
-// 	CHANNEL = 'channel',
-// }
-// export enum ChatVisibility {
-// 	PUBLIC = 'public',
-// 	PRIVATE = 'private',
-// }
 export type ChatType = 'dm' | 'channel';
 export type ChatVisibility = 'public' | 'private';
 

--- a/backend/src/chats/chat/entities/chat.entity.ts
+++ b/backend/src/chats/chat/entities/chat.entity.ts
@@ -7,6 +7,16 @@ import { User } from '../../../users/user/entities/user.entity';
 
 const validVisibility = ['public', 'private'];
 const chatType = ['dm', 'channel'];
+// export enum ChatType {
+// 	DM = 'dm',
+// 	CHANNEL = 'channel',
+// }
+// export enum ChatVisibility {
+// 	PUBLIC = 'public',
+// 	PRIVATE = 'private',
+// }
+export type ChatType = 'dm' | 'channel';
+export type ChatVisibility = 'public' | 'private';
 
 @Entity('chats')
 export class Chat {
@@ -42,11 +52,11 @@ export class Chat {
 
 	@IsIn(validVisibility)
 	@Column({ default: 'public' })
-	visibility: string;
+	visibility: ChatVisibility;
 
 	@IsIn(chatType)
 	@Column({ default: 'channel' })
-	type: string;
+	type: ChatType;
 
 	@Column({ nullable: true })
 	@Exclude()

--- a/backend/src/chats/message/entities/message.entity.ts
+++ b/backend/src/chats/message/entities/message.entity.ts
@@ -33,7 +33,10 @@ export class Message {
 	@RelationId((message: Message) => message.sender_id)
 	user_id: number;
 
-	@ManyToOne(() => Chat, (chat) => chat.id, { nullable: false })
+	@ManyToOne(() => Chat, (chat) => chat.id, {
+		nullable: false,
+		onDelete: 'CASCADE',
+	})
 	@JoinColumn({ name: 'chat' })
 	chat: Chat;
 

--- a/backend/src/chats/message/message.spec.ts
+++ b/backend/src/chats/message/message.spec.ts
@@ -23,8 +23,8 @@ describe('MessageController', () => {
 	let userService: UserService;
 
 	const testChats: CreateChatDto[] = [
-		{ name: 'A', visibility: 'Not', password: 'A' },
-		{ name: 'B', visibility: 'Yes', password: 'B' },
+		{ name: 'A', visibility: 'private', password: 'A' },
+		{ name: 'B', visibility: 'public', password: 'B' },
 	];
 
 	const testMessages: CreateMessageDto[] = [

--- a/backend/src/seeders/seed.data.ts
+++ b/backend/src/seeders/seed.data.ts
@@ -87,8 +87,8 @@ const seedData = {
 				updated_at: user_dates[3],
 			},
 			{
-				name: 'X the bitch',
-				password: await bcrypt.hash('x', 11),
+				name: 'wildsbok',
+				password: await bcrypt.hash('w', 11),
 				is_intra: false,
 				created_at: user_dates[4],
 				updated_at: user_dates[4],

--- a/backend/test/chat.e2e-spec.ts
+++ b/backend/test/chat.e2e-spec.ts
@@ -12,8 +12,8 @@ describe('chat e2e', () => {
 	let chatController: ChatController;
 
 	const testChats: CreateChatDto[] = [
-		{ name: 'A', visibility: 'Not', password: 'A' },
-		{ name: 'B', visibility: 'Yes', password: 'B' },
+		{ name: 'A', visibility: 'private', password: 'A' },
+		{ name: 'B', visibility: 'public', password: 'B' },
 	];
 
 	beforeAll(async () => {

--- a/frontend/src/types/Chat.ts
+++ b/frontend/src/types/Chat.ts
@@ -33,6 +33,8 @@ export interface NewMessage {
 	content: string;
 }
 
+export type ChatVisibility = 'public' | 'private';
+
 export interface Chat {
 	id: number;
 	name: string;
@@ -40,7 +42,7 @@ export interface Chat {
 	has_users: UserChatPermissions[];
 	users: User;
 
-	visibility: string;
+	visibility: ChatVisibility;
 	password: string;
 
 	messages: SingleMessage[];


### PR DESCRIPTION
Adds a permission check to the chat/:id/messages endpoint
added comments in the code to describe what it is doing this time :P 

Also refactored the chat visibility and chat type (actual types now instead of strings, but I honestly had never used `export type` before working on the frontend..)

also renamed the last test user to be more in line with our other usernames (for ryno :))

closes #164 